### PR TITLE
Clean up persistence configuration

### DIFF
--- a/untitled/pom.xml
+++ b/untitled/pom.xml
@@ -52,10 +52,5 @@
             <version>42.6.0</version>
         </dependency>
 
-        <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
-            <version>2.2</version>
-        </dependency>
     </dependencies>
 </project>

--- a/untitled/src/main/java/org/example/Main.java
+++ b/untitled/src/main/java/org/example/Main.java
@@ -1,8 +1,7 @@
 package org.example;
 
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.EntityManagerFactory;
-import jakarta.persistence.Persistence;
+import org.example.config.JPAUtil;
 import jakarta.persistence.TypedQuery;
 import org.example.entity.Person;
 
@@ -10,9 +9,8 @@ import java.util.List;
 
 public class Main {
     public static void main(String[] args) {
-        // Создаём фабрику EntityManager по имени persistence-unit
-        EntityManagerFactory emf = Persistence.createEntityManagerFactory("example-unit");
-        EntityManager em = emf.createEntityManager();
+        // Получаем EntityManager из утилиты, использующей пул соединений
+        EntityManager em = JPAUtil.getEntityManager();
 
         try {
             // Начинаем транзакцию (для RESOURCE_LOCAL обязателен)
@@ -33,7 +31,7 @@ public class Main {
             e.printStackTrace();
         } finally {
             em.close();
-            emf.close();
+            JPAUtil.close();
         }
     }
 }

--- a/untitled/src/main/java/org/example/config/JPAUtil.java
+++ b/untitled/src/main/java/org/example/config/JPAUtil.java
@@ -1,12 +1,34 @@
 package org.example.config;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class JPAUtil {
-    private static final EntityManagerFactory emf =
-            Persistence.createEntityManagerFactory("myPU");
+    private static final HikariDataSource dataSource;
+    private static final EntityManagerFactory emf;
+
+    static {
+        HikariConfig config = new HikariConfig();
+        config.setDriverClassName("org.postgresql.Driver");
+        config.setJdbcUrl("jdbc:postgresql://localhost:5432/postgres?charSet=UTF-8");
+        config.setUsername("postgres");
+        config.setPassword("postgres");
+        config.setMinimumIdle(5);
+        config.setMaximumPoolSize(10);
+        config.setIdleTimeout(300000);
+
+        dataSource = new HikariDataSource(config);
+
+        Map<String, Object> props = new HashMap<>();
+        props.put("jakarta.persistence.nonJtaDataSource", dataSource);
+        emf = Persistence.createEntityManagerFactory("example-unit", props);
+    }
 
     public static EntityManager getEntityManager() {
         return emf.createEntityManager();
@@ -14,6 +36,7 @@ public class JPAUtil {
 
     public static void close() {
         emf.close();
+        dataSource.close();
     }
 }
 

--- a/untitled/src/main/java/org/example/dto/AbstractDAO.java
+++ b/untitled/src/main/java/org/example/dto/AbstractDAO.java
@@ -2,8 +2,8 @@ package org.example.dto;
 
 import org.example.config.JPAUtil;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityTransaction;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
 import java.io.Serializable;
 import java.lang.reflect.ParameterizedType;
 import java.util.List;

--- a/untitled/src/main/resources/META-INF/persistence.xml
+++ b/untitled/src/main/resources/META-INF/persistence.xml
@@ -9,21 +9,10 @@
         <class>org.example.entity.Person</class>
 
         <properties>
-            <!-- JDBC -->
-            <property name="jakarta.persistence.jdbc.driver" value="org.postgresql.Driver"/>
-            <property name="jakarta.persistence.jdbc.url" value="jdbc:postgresql://localhost:5432/postgres?charSet=UTF-8"/>
-            <property name="jakarta.persistence.jdbc.user" value="postgres"/>
-            <property name="jakarta.persistence.jdbc.password" value="postgres"/>
+            <!-- Источник данных и JDBC-параметры передаются программно через JPAUtil -->
 
             <!-- Диалект -->
             <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect"/>
-
-            <!-- HikariCP в качестве ConnectionProvider -->
-            <property name="hibernate.connection.provider_class"
-                      value="org.hibernate.hikaricp.internal.HikariCPConnectionProvider"/>
-            <property name="hibernate.hikari.minimumIdle" value="5"/>
-            <property name="hibernate.hikari.maximumPoolSize" value="10"/>
-            <property name="hibernate.hikari.idleTimeout" value="300000"/>
 
             <!-- Отладка SQL -->
             <property name="hibernate.show_sql" value="true"/>


### PR DESCRIPTION
## Summary
- avoid duplicating JDBC properties in `persistence.xml`
- pool is still configured programmatically in `JPAUtil`

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6887e14c8aa08326a223490a1ec7d5aa